### PR TITLE
bug fix - combined mapped arg with blank string

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -52,7 +52,7 @@ log.init = function() {
       const args = Array.from(arguments);
       if (name !== 'INFO') args.unshift('[' + name + ']');
 
-      let s = args.map(x => x.toString()).join(' ');
+      let s = args.map(x => ('' + x.toString())).join(' ');
       if (level.color) s = chalk[level.color](s);
 
       this.output(s);


### PR DESCRIPTION
combined x.toString() result with blank string to avoid exception in case x is invalid/undefined, failing to call toString()

let s = args.map(x => x.toString()).join(' ');
                              ^
TypeError: Cannot read properties of undefined (reading 'toString')